### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # StackHawk Developer Training: Getting Started With HawkScan 
 
 
+
 This training is geared towards the developer audience and aims to get users started with using **StackHawks DAST** (Dynamic Application Security Testing) tool, **HawkScan**. This step-by-step training allows you to see the power of HawkScan firsthand. 
 
-### **Throughout the duration of this training, we will cover the following.** 
+### **Throughout the duration of this training, we will cover the following.**    
 
 * Introduction to StackHawk
 * Locally Installing Hawkscan
@@ -14,66 +15,43 @@ This training is geared towards the developer audience and aims to get users sta
 * Configuring The Scanner
 * Scanning Best Practices
 
-The slide deck for this training can be previewed via the links below!
+The slide deck for this training can be previewed via the link below!
 
-[**MacOS Developer Training**](https://docs.google.com/presentation/d/11Gz7drmMcQiBECrRqU7LO89f300z2pqUPp1fA7bTDFs/edit?usp=sharing) |
-[**Windows Developer Training**](https://docs.google.com/presentation/d/1kwfX6t-Q0hAnqpUfZfcaPkNVh8pexKI0iGnZBoH3lw8/edit?usp=sharing)
+[**Intro to HawkScan - Developer Training**](https://docs.google.com/presentation/d/17EsdIR7N_I6CMk3gdTHICbeW7uO8l1pzcPNhfrhj4V8/edit?usp=sharing) 
 
 # Prerequisites
+The following prerequisites are required to complete this hands-on training successfully. Regardless of Operating System, (MacOS, Linux, Windows) the prerequisites are the same.
 
 
-### **StackHawk Account Access**
+<details>
+<summary>StackHawk Account Access</summary>
 
 To successfully participate in & complete this training, you will need access to your organization's StackHawk account with permission to create new applications and API Keys.
 
->_If you already have access to a StackHawk Account, please do not create an additional Organization. Doing so will create added steps to the training..._
+> _If you already have access to a StackHawk Account, please do not create an additional Organization. Doing so will create added steps to the training..._
 
 You can log in to your StackHawk Account by navigating to [**app.stackhawk.com**](app.stackhawk.com). 
-### **OS Specific Prerequisites**
+</details>
+
 <details>
-<summary><ins>MacOS</summary>
+<summary>Java JDK</summary>
 
 
- ### [**HomeBrew**](https://docs.brew.sh/Installation)
- HomeBrew is required to download and install the HawkScan CLI Tool. Check your current HomeBrew version by running the following command in your terminal and update as needed.
-
- ```
- brew --version
-```
-
- ### [**Java JDK**](https://www.oracle.com/java/technologies/downloads/#jdk21-mac)
- Java JDK will be required to run HawkScan locally on your computer. To check your current version, run the following command in your terminal
+ Java JDK **(Version 11 or Higher)** will be required to run HawkScan locally on your computer. To check your current version, run the following command in your terminal
 
  ```
  java -version
 ```  
- 
-> IMPORTANT! :
-> Java Version 11 or Higher Required.
-
+You can download a recent version of Java Development Kit, [**here!**](https://adoptium.net/)
 </details>
 
-<details>
-<summary><ins>Windows</summary>
- 
 
 
- ### [**Java JDK**](https://www.oracle.com/java/technologies/downloads/#jdk21-windows)
- Java JDK will be required to run HawkScan locally on your computer. To check your current version, run the following command in your terminal
-
- ```
- java -version
-```  
- 
-> IMPORTANT! :
-> Java Version 11 or Higher Required.
-
-</details>
 
 # HawkScan Training Guides
 Below, you can find the OS-specific, step-by-step guides that are to be followed in tandem with this training. These include all commands and instructions needed to follow along.
 
-## [**MacOS Training Guide**](MacOSTrainingGuide.md) 
+## [**MacOS / Linux Training Guide**](MacOS-LinuxTrainingGuide.md) 
 ## [**Windows Training Guide**](WindowsOSTrainingGuide.md)
 
 You are more than welcome to get a head start on the above steps prior to training or to follow these guides at your own pace.


### PR DESCRIPTION
- Removing Pre-requisites for HomeBrew (Switching to PKG Installer)
- Removing OS specific pre-requisites (Moving to PKG installer, allows users regardless of OS to only need Java)
- Changing Java download links to Adoptium. 
- Changing language to include Linux in MacOS training guides.
- Updated link to a single slide deck for both OS training paths.