### PR TITLE
Update HawkScan version references from 5.1.0 to 5.3.0

### DIFF
--- a/MacOS-LinuxTrainingGuide.es.md
+++ b/MacOS-LinuxTrainingGuide.es.md
@@ -9,9 +9,9 @@ Existen múltiples métodos de instalación y [descarga](https://docs.stackhawk.
 
 
 ```
-curl -v https://download.stackhawk.com/hawk/pkg/hawk-5.1.0.pkg -o hawk-5.1.0.pkg &&\
-sudo installer -pkg hawk-5.1.0.pkg -target /Applications &&\
-rm hawk-5.1.0.pkg
+curl -v https://download.stackhawk.com/hawk/pkg/hawk-5.3.0.pkg -o hawk-5.3.0.pkg &&\
+sudo installer -pkg hawk-5.3.0.pkg -target /Applications &&\
+rm hawk-5.3.0.pkg
 ```
 
 Puede comprobar qué versión de HawkScan tiene instalada actualmente ejecutando,
@@ -19,7 +19,7 @@ Puede comprobar qué versión de HawkScan tiene instalada actualmente ejecutando
 ```
 hawk version
 ```
->La última versión es v5.1.0.
+>La última versión es v5.3.0.
 
 
 ## Paso 2: _Autenticación de StackHawk_

--- a/MacOS-LinuxTrainingGuide.md
+++ b/MacOS-LinuxTrainingGuide.md
@@ -9,9 +9,9 @@ There are multiple install methods and [downloads](https://docs.stackhawk.com/do
 
 
 ```
-curl -v https://download.stackhawk.com/hawk/pkg/hawk-5.1.0.pkg -o hawk-5.1.0.pkg &&\
-sudo installer -pkg hawk-5.1.0.pkg -target /Applications &&\
-rm hawk-5.1.0.pkg
+curl -v https://download.stackhawk.com/hawk/pkg/hawk-5.3.0.pkg -o hawk-5.3.0.pkg &&\
+sudo installer -pkg hawk-5.3.0.pkg -target /Applications &&\
+rm hawk-5.3.0.pkg
 ```
 
 You can check to see what version of HawkScan you currently have installed by running,
@@ -19,7 +19,7 @@ You can check to see what version of HawkScan you currently have installed by ru
 ```
 hawk version
 ```
->v5.1.0 is the latest
+>v5.3.0 is the latest
 
 
 ## Step 2: _Authenticating To StackHawk_

--- a/WindowsOSTrainingGuide.es.md
+++ b/WindowsOSTrainingGuide.es.md
@@ -9,7 +9,7 @@ Existen múltiples métodos de instalación y [descarga](https://docs.stackhawk.
 
 
 ```
-msiexec.exe /i https://download.stackhawk.com/hawk/msi/hawk-5.1.0.msi /passive
+msiexec.exe /i https://download.stackhawk.com/hawk/msi/hawk-5.3.0.msi /passive
 ```
 
 Puede comprobar qué versión de HawkScan tiene instalada actualmente ejecutando,
@@ -17,7 +17,7 @@ Puede comprobar qué versión de HawkScan tiene instalada actualmente ejecutando
 ```
 hawk version
 ```
->La última versión es v5.1.0.
+>La última versión es v5.3.0.
 
 
 ## Paso 2: _Autenticación de StackHawk_

--- a/WindowsOSTrainingGuide.md
+++ b/WindowsOSTrainingGuide.md
@@ -9,7 +9,7 @@ There are multiple install methods and [downloads](https://docs.stackhawk.com/do
 
 
 ```
-msiexec.exe /i https://download.stackhawk.com/hawk/msi/hawk-5.1.0.msi /passive
+msiexec.exe /i https://download.stackhawk.com/hawk/msi/hawk-5.3.0.msi /passive
 ```
 
 You can check to see what version of HawkScan you currently have installed by running,
@@ -17,7 +17,7 @@ You can check to see what version of HawkScan you currently have installed by ru
 ```
 hawk version
 ```
->v5.1.0 is the latest
+>v5.3.0 is the latest
 
 
 ## Step 2: _Authenticating To StackHawk_


### PR DESCRIPTION
Updated all training guide documentation to reference the latest HawkScan version 5.3.0 instead of the outdated 5.1.0 version. This includes installation commands and version references in both English and Spanish guides for MacOS/Linux and Windows platforms.

